### PR TITLE
[EE4J_8] Fixes #79: bundle symbolic name should match artifactId

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 
-    Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
    
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions

--- a/jaxb-api/pom.xml
+++ b/jaxb-api/pom.xml
@@ -106,14 +106,6 @@
                     <configuration>
                         <archive>
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                            <manifestEntries>
-                                <Extension-Name>javax.xml.bind</Extension-Name>
-                                <Implementation-Build-Id>${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
-                                <Multi-Release>true</Multi-Release>
-                            </manifestEntries>
-                            <manifest>
-                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            </manifest>
                         </archive>
                     </configuration>
                 </plugin>
@@ -142,8 +134,8 @@
                             <Bundle-Version>${project.version}</Bundle-Version>  <!-- 2.2.99.bnull -->
                             <Extension-Name>${extension.name}</Extension-Name>
                             <Implementation-Version>${spec.version}.${impl.version}</Implementation-Version>
-                            <Specification-Version>${project.version}</Specification-Version>
-                            <Export-Package>${extension.name}.*; version=${spec.version}</Export-Package>
+                            <Specification-Version>${spec.version}</Specification-Version>
+                            <Export-Package>${api.package}.*; version=${spec.version}</Export-Package>
                             <Import-Package>
                                 javax.activation;version=!,
                                 javax.xml.bind;version="[${spec.version},3)",
@@ -166,9 +158,11 @@
                                 org.xml.sax.ext,
                                 org.xml.sax.helpers
                             </Import-Package>
-                            <Bundle-SymbolicName>jakarta.xml.bind-api</Bundle-SymbolicName>
+                            <Bundle-SymbolicName>${extension.name}-api</Bundle-SymbolicName>
                             <DynamicImport-Package>org.glassfish.hk2.osgiresourcelocator</DynamicImport-Package>
                             <Specification-Vendor>${vendor.name}</Specification-Vendor>
+                            <Implementation-Build-Id>${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                            <Multi-Release>true</Multi-Release>
                         </instructions>
                     </configuration>
                 </plugin>
@@ -203,7 +197,7 @@
                         <author>true</author>
                         <version>true</version>
                         <doctitle><![CDATA[<br>
-JAXB ${project.version} Runtime Library</h2>
+JAXB ${project.version} API Library</h2>
 ${project.name} specification, ${release.spec.date}<br>
 Comments to: <i><a href='mailto:${release.spec.feedback}'>${release.spec.feedback}</a></i><br>
 More information at: <i><a target='_top'
@@ -257,7 +251,6 @@ href='https://projects.eclipse.org/projects/ee4j.jaxb'>https://projects.eclipse.
                         </execution>
                         <execution>
                             <id>module-info-compile</id>
-                            <phase>test-compile</phase><!--Avoid JavaSE9 capability added by bundle-plugin-->
                             <goals>
                                 <goal>compile</goal>
                             </goals>
@@ -311,13 +304,6 @@ href='https://projects.eclipse.org/projects/ee4j.jaxb'>https://projects.eclipse.
                             <resources>
                                 <resource>
                                     <directory>${java9.build.outputDirectory}</directory>
-                                </resource>
-                                <!-- Copy module-info.class to java >= 9 classes directory. Source file will be deleted later with ant. -->
-                                <resource>
-                                    <directory>${project.build.outputDirectory}</directory>
-                                    <includes>
-                                        <include>module-info.class</include>
-                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>
@@ -428,19 +414,6 @@ href='https://projects.eclipse.org/projects/ee4j.jaxb'>https://projects.eclipse.
                                 <jar destfile="${project.build.directory}/jakarta.xml.bind-api-${project.version}-sources.jar" update="true">
                                     <fileset dir="${project.build.directory}/mr-jar/" />
                                 </jar>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <!-- Delete module-info.class from java < 9 classes directory. -->
-                    <execution>
-                        <id>update-target-classes</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <target>
-                                <delete file="${project.build.outputDirectory}/module-info.class"/>
                             </target>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,10 @@
         <findbugs.threshold>Low</findbugs.threshold>
         <mrjar.sourceDirectory>${project.basedir}/src/main/mr-jar</mrjar.sourceDirectory>
         <mrjar.build.outputDirectory>${project.build.directory}/classes-mrjar</mrjar.build.outputDirectory>
-        <extension.name>javax.xml.bind</extension.name>
+        <api.package>javax.xml.bind</api.package>
+        <extension.name>jakarta.xml.bind</extension.name>
         <spec.version>2.3</spec.version>
-        <impl.version>0</impl.version>
+        <impl.version>2</impl.version>
         <activation.version>1.2.1</activation.version>
         <config.dir>${project.basedir}/etc/config</config.dir>
         <vendor.name>Oracle Corporation</vendor.name>


### PR DESCRIPTION
Fixes #79 in ee4j_8 branch

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>