### PR TITLE
Non Java SE default context factory for JDK's > 8

### DIFF
--- a/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
@@ -38,21 +38,6 @@ import java.util.logging.Logger;
  */
 class ContextFinder {
 
-    /**
-     * When JAXB is in J2SE, rt.jar has to have a JAXB implementation.
-     * However, rt.jar cannot have META-INF/services/javax.xml.bind.JAXBContext
-     * because if it has, it will take precedence over any file that applications have
-     * in their jar files.
-     *
-     * <p>
-     * When the user bundles his own JAXB implementation, we'd like to use it, and we
-     * want the platform default to be used only when there's no other JAXB provider.
-     *
-     * <p>
-     * For this reason, we have to hard-code the class name into the API.
-     */
-    private static final String PLATFORM_DEFAULT_FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory";
-
     // previous value of JAXBContext.JAXB_CONTEXT_FACTORY, using also this to ensure backwards compatibility
     private static final String JAXB_CONTEXT_FACTORY_DEPRECATED = "javax.xml.bind.context.factory";
 
@@ -140,7 +125,7 @@ class ContextFinder {
                                    Map properties) throws JAXBException {
 
         try {
-            Class spFactory = ServiceLoaderUtil.safeLoadClass(className, PLATFORM_DEFAULT_FACTORY_CLASS, classLoader);
+            Class spFactory = ServiceLoaderUtil.safeLoadClass(className, ModuleUtil.DEFAULT_FACTORY_CLASS, classLoader);
             return newInstance(contextPath, contextPathClasses, spFactory, classLoader, properties);
         } catch (ClassNotFoundException x) {
             throw new JAXBException(Messages.format(Messages.DEFAULT_PROVIDER_NOT_FOUND), x);
@@ -242,7 +227,7 @@ class ContextFinder {
 
         Class spi;
         try {
-            spi = ServiceLoaderUtil.safeLoadClass(className, PLATFORM_DEFAULT_FACTORY_CLASS, getContextClassLoader());
+            spi = ServiceLoaderUtil.safeLoadClass(className, ModuleUtil.DEFAULT_FACTORY_CLASS, getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw new JAXBException(Messages.format(Messages.DEFAULT_PROVIDER_NOT_FOUND), e);
         }
@@ -330,7 +315,7 @@ class ContextFinder {
 
         // else no provider found
         logger.fine("Trying to create the platform default provider");
-        return newInstance(contextPath, contextPathClasses, PLATFORM_DEFAULT_FACTORY_CLASS, classLoader, properties);
+        return newInstance(contextPath, contextPathClasses, ModuleUtil.DEFAULT_FACTORY_CLASS, classLoader, properties);
     }
 
     static JAXBContext find(Class<?>[] classes, Map<String, ?> properties) throws JAXBException {
@@ -387,7 +372,7 @@ class ContextFinder {
 
         // else no provider found
         logger.fine("Trying to create the platform default provider");
-        return newInstance(classes, properties, PLATFORM_DEFAULT_FACTORY_CLASS);
+        return newInstance(classes, properties, ModuleUtil.DEFAULT_FACTORY_CLASS);
     }
 
 

--- a/jaxb-api/src/main/java/javax/xml/bind/ModuleUtil.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ModuleUtil.java
@@ -21,6 +21,21 @@ import java.io.IOException;
 class ModuleUtil {
 
     /**
+     * When JAXB is in J2SE, rt.jar has to have a JAXB implementation.
+     * However, rt.jar cannot have META-INF/services/javax.xml.bind.JAXBContext
+     * because if it has, it will take precedence over any file that applications have
+     * in their jar files.
+     *
+     * <p>
+     * When the user bundles his own JAXB implementation, we'd like to use it, and we
+     * want the platform default to be used only when there's no other JAXB provider.
+     *
+     * <p>
+     * For this reason, we have to hard-code the class name into the API.
+     */
+    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory";
+
+    /**
      * Resolves classes from context path.
      * Only one class per package is needed to access its {@link java.lang.Module}
      */

--- a/jaxb-api/src/main/mr-jar/javax/xml/bind/ModuleUtil.java
+++ b/jaxb-api/src/main/mr-jar/javax/xml/bind/ModuleUtil.java
@@ -30,6 +30,11 @@ class ModuleUtil {
     private static Logger logger = Logger.getLogger("javax.xml.bind");
 
     /**
+     * JAXB-RI default context factory.
+     */
+    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.bind.v2.ContextFactory";
+
+    /**
      * Resolves classes from context path.
      * Only one class per package is needed to access its {@link java.lang.Module}
      */


### PR DESCRIPTION
Compatible with both pre and post JavaSE 8 environments.
Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>