### PR TITLE
Prevent Java Compiler inlining of default ModuleUtil.DEFAULT_FACTORY_CLASS

### DIFF
--- a/jaxb-api/src/main/java/javax/xml/bind/ModuleUtil.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ModuleUtil.java
@@ -33,7 +33,8 @@ class ModuleUtil {
      * <p>
      * For this reason, we have to hard-code the class name into the API.
      */
-    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory";
+    // NOTICE: .toString() is used to prevent constant inlining by Java Compiler
+    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory".toString();
 
     /**
      * Resolves classes from context path.

--- a/jaxb-api/src/main/mr-jar/javax/xml/bind/ModuleUtil.java
+++ b/jaxb-api/src/main/mr-jar/javax/xml/bind/ModuleUtil.java
@@ -32,7 +32,8 @@ class ModuleUtil {
     /**
      * JAXB-RI default context factory.
      */
-    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.bind.v2.ContextFactory";
+    // NOTICE: .toString() is used to prevent constant inlining by Java Compiler
+    static final String DEFAULT_FACTORY_CLASS = "com.sun.xml.bind.v2.ContextFactory".toString();
 
     /**
      * Resolves classes from context path.


### PR DESCRIPTION
Fix for https://github.com/eclipse-ee4j/jaxb-api/issues/78