### PR TITLE
#101: minimal changes in javadocs

### DIFF
--- a/jaxb-api/pom.xml
+++ b/jaxb-api/pom.xml
@@ -141,7 +141,7 @@
                         <author>true</author>
                         <version>true</version>
                         <doctitle><![CDATA[<br>
-JAXB ${project.version} API Library</h2>
+Jakarta XML Binding ${project.version} API Library</h2>
 ${project.name} specification, ${release.spec.date}<br>
 Comments to: <i><a href='mailto:${release.spec.feedback}'>${release.spec.feedback}</a></i><br>
 More information at: <i><a target='_top'
@@ -149,11 +149,13 @@ href='https://projects.eclipse.org/projects/ee4j.jaxb'>https://projects.eclipse.
 &nbsp;<br>&nbsp;<br><hr width='65%'><h1>${project.name}</h1><hr width='75%'>
 <br>&nbsp;<br>]]>
                         </doctitle>
-                        <header><![CDATA[JAXB<br>v${project.version}]]>
+                        <header><![CDATA[Jakarta XML Binding<br>v${project.version}]]>
                         </header>
                         <bottom>
-                        <![CDATA[<br>Copyright &#169; {inceptionYear}&#x2013;{currentYear} Oracle and/or its affiliates.
-                        All rights reserved.<br>Comments to : <a href="mailto:${release.spec.feedback}">${release.spec.feedback}</a>.]]>
+                        <![CDATA[
+Comments to : <a href="mailto:${release.spec.feedback}">${release.spec.feedback}</a>.<br>
+Copyright &#169; {inceptionYear}&#x2013;{currentYear} Oracle and/or its affiliates. All rights reserved.<br>
+Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                         </bottom>
                         <detectJavaApiLink>false</detectJavaApiLink>
                         <tags>

--- a/jaxb-api/src/main/java/javax/xml/bind/annotation/adapters/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/annotation/adapters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,12 +10,15 @@
 
 /**
  * {@link javax.xml.bind.annotation.adapters.XmlAdapter} and its spec-defined
- * sub-classes to allow arbitrary Java classes to be used with JAXB.
+ * sub-classes to allow arbitrary Java classes to be used with Jakarta XML Binding.
  * 
+ * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ *
  * <h2>Package Specification</h2>
  * 
  * <ul>
- * <li><a href="http://jcp.org/en/jsr/detail?id=222">JAXB Specification</a>
+ * <li><a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Specification project</a>
  * </ul>
  * 
  * <h2>Related Documentation</h2>
@@ -23,9 +26,9 @@
  * For overviews, tutorials, examples, guides, and tool documentation,
  * please see:
  * <ul>
- * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  * </ul>
  *
- * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  */
 package javax.xml.bind.annotation.adapters;

--- a/jaxb-api/src/main/java/javax/xml/bind/annotation/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/annotation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,6 +11,8 @@
 /**
  * Defines annotations for customizing Java program elements to XML Schema mapping.
  * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ *
  * <h2>Package Specification</h2>
  * <p>The following table shows the JAXB mapping annotations
  * that can be associated with each program element. </p>

--- a/jaxb-api/src/main/java/javax/xml/bind/attachment/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/attachment/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -18,12 +18,14 @@
  * optimized transmission of binary datatypes as an attachment.
  * To optimally support these standards within a message passing
  * environment, this package enables an integrated solution between
- * a MIME-based package processor and JAXB unmarshall/marshal processes.
+ * a MIME-based package processor and Jakarta XML Binding unmarshall/marshal processes.
  * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ *
  * <h2>Package Specification</h2>
  * <p>
  * <ul>
- * <li><a href="http://jcp.org/en/jsr/detail?id=222">JAXB Specification</a>
+ * <li><a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Specification project</a>
  * </ul>
  * <p>
  * <h2>Related Standards</h2>

--- a/jaxb-api/src/main/java/javax/xml/bind/helpers/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/helpers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -9,17 +9,20 @@
  */
 
 /**
- * <B>JAXB Provider Use Only:</b> Provides partial default implementations for
+ * <B>Jakarta XML Binding Provider Use Only:</b> Provides partial default implementations for
  * some of the <code>javax.xml.bind</code> interfaces.
  *
  * <p>
- * JAXB Providers can extend these classes and implement the abstract
+ * Jakarta XML Binding Providers can extend these classes and implement the abstract
  * methods.
+ *
+ * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
  *
  * <h2>Package Specification</h2>
  *
  * <ul>
- * <li><a href="http://jcp.org/en/jsr/detail?id=222">JAXB Specification</a>
+ * <li><a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Specification project</a>
  * </ul>
  *
  * <h2>Related Documentation</h2>
@@ -27,9 +30,9 @@
  * For overviews, tutorials, examples, guides, and tool documentation,
  * please see:
  * <ul>
- * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  * </ul>
  *
- * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  */
 package javax.xml.bind.helpers;

--- a/jaxb-api/src/main/java/javax/xml/bind/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -17,10 +17,12 @@
  * framework.
  * <p>
  * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ *
  * <h2>Package Specification</h2>
  * <p>
  * <ul>
- * <li><a href="http://jcp.org/en/jsr/detail?id=222">JAXB Specification</a>
+ * <li><a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Specification project</a>
  * </ul>
  * <p>
  * <h2>Related Documentation</h2>
@@ -28,9 +30,9 @@
  * For overviews, tutorials, examples, guides, and tool documentation,
  * please see:
  * <ul>
- * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  * </ul>
  *
- * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  */
 package javax.xml.bind;

--- a/jaxb-api/src/main/java/javax/xml/bind/util/package-info.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,10 +11,13 @@
 /**
  * Useful client utility classes.
  *
+ * <p>
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ *
  * <h2>Package Specification</h2>
  *
  * <ul>
- * <li><a href="http://jcp.org/en/jsr/detail?id=222">JAXB Specification</a>
+ * <li><a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Specification project</a>
  * </ul>
  *
  * <h2>Related Documentation</h2>
@@ -22,9 +25,9 @@
  * For overviews, tutorials, examples, guides, and tool documentation,
  * please see:
  * <ul>
- * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * <li>The <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  * </ul>
  *
- * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">JAXB Website</a>
+ * @see <a href="https://projects.eclipse.org/projects/ee4j.jaxb">Jakarta XML Binding Website</a>
  */
 package javax.xml.bind.util;

--- a/jaxb-api/src/main/java/module-info.java
+++ b/jaxb-api/src/main/java/module-info.java
@@ -7,7 +7,9 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
+/**
+ * References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted.
+ */
 module java.xml.bind {
     requires transitive jakarta.activation;
     requires transitive java.xml;

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,7 +22,7 @@
     <groupId>jakarta.xml.bind</groupId>
     <artifactId>jakarta.xml.bind-spec</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <name>Jakarta XML Binding Specification</name>
 
     <properties>
@@ -68,7 +68,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>(,1.9),[11,)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <message>You need JDK8 or newer</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Since there are many references to 'JAXB', I propose following - minimal - changes to javadoc only.

Key entry points (module javadoc and package javadoc pages) do contain _References in this document to JAXB refer to the Jakarta XML Binding unless otherwise noted._ note on the prominent place
