### PR TITLE
Additional updates for renaming `javax.*` to `jakarta.*`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+**/.classpath
+**/.project
+.settings/

--- a/jaxb-api-test/src/main/java/jakarta/xml/bind/tests/SampleTest.java
+++ b/jaxb-api-test/src/main/java/jakarta/xml/bind/tests/SampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package java.xml.bind.tests;
+package jakarta.xml.bind.tests;
 
 /**
  * Sample test class

--- a/jaxb-api/exclude.xml
+++ b/jaxb-api/exclude.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,7 +16,7 @@
     As designed.
     -->
     <Match>
-        <Class name="javax.xml.bind.util.JAXBSource$1"/>
+        <Class name="jakarta.xml.bind.util.JAXBSource$1"/>
         <Bug pattern="XFB_XML_FACTORY_BYPASS"/>
     </Match>
 
@@ -25,7 +25,7 @@
     As designed, impossible to change, maybe with MR.
     -->
     <Match>
-        <Class name="javax.xml.bind.DatatypeConverterImpl"/>
+        <Class name="jakarta.xml.bind.DatatypeConverterImpl"/>
         <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
     </Match>
 
@@ -34,7 +34,7 @@
     As designed, impossible to change, maybe with MR?
     -->
     <Match>
-        <Class name="javax.xml.bind.annotation.adapters.HexBinaryAdapter"/>
+        <Class name="jakarta.xml.bind.annotation.adapters.HexBinaryAdapter"/>
         <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
     </Match>
 
@@ -42,7 +42,7 @@
       https://github.com/eclipse-ee4j/jaxb-api/issues/78
     -->
     <Match>
-        <Class name="javax.xml.bind.ModuleUtil"/>
+        <Class name="jakarta.xml.bind.ModuleUtil"/>
         <Bug pattern="DM_STRING_TOSTRING"/>
     </Match>
 

--- a/jaxb-api/src/main/java/jakarta/xml/bind/ContextFinder.java
+++ b/jaxb-api/src/main/java/jakarta/xml/bind/ContextFinder.java
@@ -157,7 +157,7 @@ class ContextFinder {
             /*
              * jakarta.xml.bind.context.factory points to a class which has a
              * static method called 'createContext' that
-             * returns a javax.xml.JAXBContext.
+             * returns a jakarta.xml.bind.JAXBContext.
              */
 
             Object context = null;


### PR DESCRIPTION
This PR intends to resolve issue #126 

It renames the `javax.xml.bind.*` packages to `jakarta.xml.bind.*` in the API and tests.  This includes changing constants like system properties (i.e. `javax.xml.bind.JAXBContextFactory` to `jakarta.xml.bind.JAXBContextFactory`) and service loader paths (i.e. `META-INF/services/javax.xml.bind.JAXBContextFactory` to `META-INF/services/jakarta.xml.bind.JAXBContextFactory`).

This also includes the Jakarta Activation dependency (`javax.activation.*` -> `jakarta.activation.*`).

This does not include any changes to the spec document or TCK.